### PR TITLE
Switch to consumer group based with 1.5.1.

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -31,3 +31,9 @@ The documentation is also setup at `readthedocs.io` under the account: `IBMStrea
 Documentation links:
 * http://streamsxmessagehub.readthedocs.io/en/pypackage
 
+```
+pip install 'git+https://github.com/IBMStreams/streamsx.messagehub.git@pypackage#subdirectory=python/package'
+```
+
+
+

--- a/python/package/setup.py
+++ b/python/package/setup.py
@@ -1,23 +1,25 @@
 from setuptools import setup
+import streamsx.messagehub
 setup(
   name = 'streamsx.messagehub',
   packages = ['streamsx.messagehub'],
   include_package_data=True,
-  version = '0.2.4',
-  description = 'IBM Streams Message Hub integration',
+  version = streamsx.messagehub.__version__,
+  description = 'IBM Streams Event Streams Hub integration',
   long_description = open('DESC.txt').read(),
   author = 'IBM Streams @ github.com',
   author_email = 'debrunne@us.ibm.com',
   license='Apache License - Version 2.0',
   url = 'https://github.com/ddebrunner/streamsx.messagehub',
-  keywords = ['streams', 'ibmstreams', 'streaming', 'analytics', 'streaming-analytics', 'messaging', 'messagehub'],
+  keywords = ['streams', 'ibmstreams', 'streaming', 'analytics', 'streaming-analytics', 'messaging', 'messagehub', 'events'],
   classifiers = [
-    'Development Status :: 1 - Planning',
+    'Development Status :: 3 - Alpha',
     'License :: OSI Approved :: Apache Software License',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
   ],
-  install_requires=['streamsx'],
+  install_requires=['streamsx>=1.11.5a'],
   
   test_suite='nose.collector',
   tests_require=['nose']

--- a/python/package/streamsx/messagehub/__init__.py
+++ b/python/package/streamsx/messagehub/__init__.py
@@ -61,5 +61,7 @@ a topic and the same application consuming the same topic::
 
 """
 
+__version__='0.3.1'
+
 __all__ = ['subscribe', 'publish']
 from streamsx.messagehub._messagehub import subscribe, publish

--- a/python/package/streamsx/messagehub/_messagehub.py
+++ b/python/package/streamsx/messagehub/_messagehub.py
@@ -64,7 +64,7 @@ def publish(stream, topic, credentials=None, name=None):
     _op.params['messageAttribute'] = _op.attribute(stream, msg_attr)
     
 class _MessageHubConsumer(streamsx.spl.op.Source):
-    def __init__(self, topology, schema, vmArg=None, appConfigName=None, clientId=None, messageHubCredentialsFile=None, outputKeyAttributeName=None, outputMessageAttributeName=None, outputTimestampAttributeName=None, outputOffsetAttributeName=None, outputPartitionAttributeName=None, outputTopicAttributeName=None, partition=None, propertiesFile=None, startPosition=None, startTime=None, topic=None, triggerCount=None, userLib=None, consistentRegionAssignmentMode=None, groupId=None, name=None):
+    def __init__(self, topology, schema, vmArg=None, appConfigName=None, clientId=None, messageHubCredentialsFile=None, outputKeyAttributeName=None, outputMessageAttributeName=None, outputTimestampAttributeName=None, outputOffsetAttributeName=None, outputPartitionAttributeName=None, outputTopicAttributeName=None, partition=None, propertiesFile=None, startPosition=None, startTime=None, topic=None, triggerCount=None, userLib=None, groupId=None, name=None):
         kind="com.ibm.streamsx.messagehub::MessageHubConsumer"
         inputs=None
         schemas=schema

--- a/python/package/streamsx/messagehub/tests/test_messagehub.py
+++ b/python/package/streamsx/messagehub/tests/test_messagehub.py
@@ -22,6 +22,10 @@ import uuid
 ## Message Hub has:
 ##
 ##    topic MH_TEST with one partition (1 hour retention)
+##
+##
+## Locally the toolkit exists at and is at least 1.5.1
+## $HOME/toolkits/com.ibm.streamsx.messagehub
 
 class TestSubscribeParams(TestCase):
     def test_schemas_ok(self):


### PR DESCRIPTION
Changes the subscriber to be solely using consumer groups. I believe this is the nature mechanism to use Kafka.

Assumes:
 * A 1.5.1 message hub toolkit
 * `streamsx>=1.11.5a`

I think there's more work to be done including:
 * describing how to get & use the toolkit
    * I wonder if it makes sense to embed a correct version of the toolkit in the `streamsx.messagehub` package similar to how `streamsx` embeds `com.ibm.streamsx.topology`.
 * adding Python consistent region tests

See #18